### PR TITLE
전체 문화 간단 조회 기능 추가

### DIFF
--- a/src/main/java/likelion/MZConnent/api/culture/CreateCultureController.java
+++ b/src/main/java/likelion/MZConnent/api/culture/CreateCultureController.java
@@ -1,8 +1,10 @@
 package likelion.MZConnent.api.culture;
 
+import likelion.MZConnent.domain.club.RegionCategory;
 import likelion.MZConnent.domain.culture.Culture;
 import likelion.MZConnent.domain.culture.CultureCategory;
 import likelion.MZConnent.dto.culture.request.CreateCultureRequest;
+import likelion.MZConnent.repository.club.RegionCategoryRepository;
 import likelion.MZConnent.repository.culture.CultureCategoryRepository;
 import likelion.MZConnent.repository.culture.CultureRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import java.util.Random;
 public class CreateCultureController {
     private final CultureRepository cultureRepository;
     private final CultureCategoryRepository cultureCategoryRepository;
+    private final RegionCategoryRepository regionCategoryRepository;
 
     @PostMapping("/api/cultures")
     public ResponseEntity<Culture> createCulture(@RequestBody CreateCultureRequest request) {
@@ -29,6 +32,8 @@ public class CreateCultureController {
         log.info("culture request: {}", request);
 
         CultureCategory cultureCategory = cultureCategoryRepository.findById(request.getCultureCategoryId()).orElseThrow(()-> new IllegalArgumentException("해당하는 카테고리가 존재하지 않습니다."));
+
+        RegionCategory regionCategory = regionCategoryRepository.findById(request.getRegionId()).orElseThrow(()-> new IllegalArgumentException("해당하는 지역이 존재하지 않습니다."));
 
         Culture newCulture = Culture.builder()
                 .name(request.getName())
@@ -38,6 +43,7 @@ public class CreateCultureController {
                         .getCultureImageUrl())
                 .recommendedMember(request.getRecommendedMember())
                 .cultureCategory(cultureCategory)
+                .region(regionCategory)
                 .build();
 
         Culture savedCulture = cultureRepository.save(newCulture);

--- a/src/main/java/likelion/MZConnent/api/culture/CultureController.java
+++ b/src/main/java/likelion/MZConnent/api/culture/CultureController.java
@@ -1,11 +1,16 @@
 package likelion.MZConnent.api.culture;
 
 import likelion.MZConnent.dto.culture.response.CultureCategoryResponse;
+import likelion.MZConnent.dto.culture.response.CulturesSimpleResponse;
+import likelion.MZConnent.dto.paging.response.PageContentResponse;
+import likelion.MZConnent.dto.review.response.ReviewsSimpleResponse;
 import likelion.MZConnent.service.culture.CultureCategoryService;
+import likelion.MZConnent.service.culture.CultureService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -14,11 +19,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class CultureController {
     private final CultureCategoryService cultureCategoryService;
 
+    private final CultureService cultureService;
+
     // 전체 문화 카테고리 조회
     @GetMapping("/api/categories/culture")
     public ResponseEntity<CultureCategoryResponse> getAllCultureCategories() {
         CultureCategoryResponse all = cultureCategoryService.getAllCultureCategories();
         log.info("전체 문화 카테고리: {}", all.getCultureCategories());
         return ResponseEntity.ok(all);
+    }
+
+    // 전체 문화 간단 조회
+    @GetMapping("/api/cultures")
+    ResponseEntity<PageContentResponse> getReviewSimpleList(@RequestParam(required = false, defaultValue = "0", value = "category") Long category, @RequestParam(required = false, defaultValue = "0", value = "page") int page ) {
+
+        PageContentResponse<CulturesSimpleResponse> response = cultureService.getCulturesSimpleList(category, page);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/likelion/MZConnent/domain/club/RegionCategory.java
+++ b/src/main/java/likelion/MZConnent/domain/club/RegionCategory.java
@@ -1,6 +1,7 @@
 package likelion.MZConnent.domain.club;
 
 import jakarta.persistence.*;
+import likelion.MZConnent.domain.culture.Culture;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,5 +21,7 @@ public class RegionCategory {
     @OneToMany(mappedBy = "region")
     private List<Club> clubs;
 
+    @OneToMany(mappedBy = "region")
+    private List<Culture> cultures;
 }
 

--- a/src/main/java/likelion/MZConnent/domain/culture/Culture.java
+++ b/src/main/java/likelion/MZConnent/domain/culture/Culture.java
@@ -2,6 +2,7 @@ package likelion.MZConnent.domain.culture;
 
 import jakarta.persistence.*;
 import likelion.MZConnent.domain.club.Club;
+import likelion.MZConnent.domain.club.RegionCategory;
 import likelion.MZConnent.domain.review.Review;
 import lombok.Builder;
 import lombok.Getter;
@@ -42,6 +43,10 @@ public class Culture {
     @JoinColumn(name = "cultureCategoryId", nullable = false)
     private CultureCategory cultureCategory;
 
+    @ManyToOne
+    @JoinColumn(name = "region_id")
+    private RegionCategory region;
+
     @OneToMany(mappedBy = "culture")
     private List<Club> clubs;
 
@@ -50,6 +55,7 @@ public class Culture {
 
     @OneToMany(mappedBy = "culture")
     private List<Review> reviews;
+
 
     @Builder
     public Culture(int interestCount, String content, String cultureImageUrl, String name, String summary, int clubCount, String recommendedMember, CultureCategory cultureCategory) {

--- a/src/main/java/likelion/MZConnent/domain/culture/Culture.java
+++ b/src/main/java/likelion/MZConnent/domain/culture/Culture.java
@@ -1,5 +1,6 @@
 package likelion.MZConnent.domain.culture;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import likelion.MZConnent.domain.club.Club;
 import likelion.MZConnent.domain.club.RegionCategory;
@@ -45,6 +46,7 @@ public class Culture {
 
     @ManyToOne
     @JoinColumn(name = "region_id")
+    @JsonIgnore
     private RegionCategory region;
 
     @OneToMany(mappedBy = "culture")
@@ -58,7 +60,7 @@ public class Culture {
 
 
     @Builder
-    public Culture(int interestCount, String content, String cultureImageUrl, String name, String summary, int clubCount, String recommendedMember, CultureCategory cultureCategory) {
+    public Culture(int interestCount, String content, String cultureImageUrl, String name, String summary, int clubCount, String recommendedMember, CultureCategory cultureCategory, RegionCategory region) {
         this.interestCount = interestCount;
         this.content = content;
         this.cultureImageUrl = cultureImageUrl;
@@ -67,5 +69,6 @@ public class Culture {
         this.clubCount = clubCount;
         this.recommendedMember = recommendedMember;
         this.cultureCategory = cultureCategory;
+        this.region = region;
     }
 }

--- a/src/main/java/likelion/MZConnent/dto/culture/request/CreateCultureRequest.java
+++ b/src/main/java/likelion/MZConnent/dto/culture/request/CreateCultureRequest.java
@@ -22,4 +22,6 @@ public class CreateCultureRequest {
     private String recommendedMember;
 
     private Long cultureCategoryId;
+
+    private Long regionId;
 }

--- a/src/main/java/likelion/MZConnent/dto/culture/response/CulturesSimpleResponse.java
+++ b/src/main/java/likelion/MZConnent/dto/culture/response/CulturesSimpleResponse.java
@@ -1,0 +1,32 @@
+package likelion.MZConnent.dto.culture.response;
+
+import likelion.MZConnent.domain.culture.Culture;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CulturesSimpleResponse {
+    private Long cultureId;
+    private String name;
+    private String summary;
+    private String cultureImageUrl;
+    private String cultureCategoryName;
+    private String regionName;
+    private int interestCount;
+    private int clubCount;
+
+    @Builder
+    public CulturesSimpleResponse(Culture culture) {
+        this.cultureId = culture.getCultureId();
+        this.name = culture.getName();
+        this.summary = culture.getSummary();
+        this.cultureImageUrl = culture.getCultureImageUrl();
+        this.cultureCategoryName = culture.getCultureCategory().getName();
+        this.regionName = culture.getRegion().getName();
+        this.interestCount = culture.getInterestCount();
+        this.clubCount = culture.getClubCount();
+    }
+}

--- a/src/main/java/likelion/MZConnent/repository/culture/CultureRepository.java
+++ b/src/main/java/likelion/MZConnent/repository/culture/CultureRepository.java
@@ -1,9 +1,15 @@
 package likelion.MZConnent.repository.culture;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import likelion.MZConnent.domain.culture.Culture;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CultureRepository extends JpaRepository<Culture, Long> {
+    @Query("SELECT c FROM Culture c WHERE :category = 0 OR c.cultureCategory.id = :category")
+    Page<Culture> findAllByCultureCategory(@Param("category") Long category, Pageable pageable);
 }

--- a/src/main/java/likelion/MZConnent/service/culture/CultureService.java
+++ b/src/main/java/likelion/MZConnent/service/culture/CultureService.java
@@ -1,0 +1,45 @@
+package likelion.MZConnent.service.culture;
+
+import likelion.MZConnent.domain.culture.Culture;
+import likelion.MZConnent.domain.review.Review;
+import likelion.MZConnent.dto.culture.response.CulturesSimpleResponse;
+import likelion.MZConnent.dto.paging.response.PageContentResponse;
+import likelion.MZConnent.dto.review.response.ReviewsSimpleResponse;
+import likelion.MZConnent.repository.culture.CultureRepository;
+import likelion.MZConnent.repository.review.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CultureService {
+    private final CultureRepository cultureRepository;
+    private final int PAGE_SIZE = 6;
+
+    public PageContentResponse<CulturesSimpleResponse> getCulturesSimpleList(Long cultureCategoryId, int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+        Page<Culture> cultures = cultureRepository.findAllByCultureCategory(cultureCategoryId, pageable);
+
+        List<CulturesSimpleResponse> cultureResponse = cultures.stream().map(culture -> CulturesSimpleResponse.builder()
+                .culture(culture).build()
+        ).collect(Collectors.toList());
+
+        return PageContentResponse.<CulturesSimpleResponse>builder()
+                .content(cultureResponse)
+                .totalPages(cultures.getTotalPages())
+                .totalElements(cultures.getTotalElements())
+                .size(pageable.getPageSize())
+                .build();
+
+    }
+}


### PR DESCRIPTION
- 문화 domain에 지역 저장을 위해 region column을 추가하고 양방향 연관 관계를 설정함
- 페이징 + 카테고리 선택을 포함한 문화 간단 조회 기능 추가함

+) region table의 id 100 데이터는 무관으로 저장했습니다.
<img width="211" alt="image" src="https://github.com/user-attachments/assets/c99b4710-f034-4056-8ba7-1963c6db1176">
