### PR TITLE
관심 문화 토글 기능 추가

### DIFF
--- a/src/test/java/likelion/MZConnent/service/culture/CultureServiceTest.java
+++ b/src/test/java/likelion/MZConnent/service/culture/CultureServiceTest.java
@@ -1,0 +1,78 @@
+package likelion.MZConnent.service.culture;
+
+import likelion.MZConnent.domain.culture.Culture;
+import likelion.MZConnent.domain.member.Member;
+import likelion.MZConnent.dto.culture.response.CultureCategoryResponse;
+import likelion.MZConnent.dto.culture.response.CultureDetailResponse;
+import likelion.MZConnent.repository.culture.CultureRepository;
+import likelion.MZConnent.repository.member.MemberRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+class CultureServiceTest {
+    @Autowired
+    CultureCategoryService cultureCategoryService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    CultureService cultureService;
+
+    @Autowired
+    CultureRepository cultureRepository;
+
+    @Test
+    public void getCultureCategory() throws Exception {
+        //given
+
+        //when
+        CultureCategoryResponse all = cultureCategoryService.getAllCultureCategories();
+
+        //then
+//        Assertions.assertEquals(all.getCultureCategories().size(), 5);
+    }
+
+    @Test
+    public void getCultureDetailInfo() throws Exception {
+        //given
+        Long cultureId = 1L;
+
+        //when
+        CultureDetailResponse cultureDetailInfo = cultureService.getCultureDetailInfo(cultureId);
+
+        //then
+        log.info("문화: {}", cultureDetailInfo);
+        Assertions.assertEquals(cultureDetailInfo.getCultureId(), 1L);
+    }
+
+    @Test
+//    @Rollback(value = false)
+    public void addCultureInterest() throws Exception {
+        //given
+        Culture culture = cultureRepository.findById(4L).get();
+        Member member  = memberRepository.findById(2L).get();
+
+        //when
+        int interestCount = cultureService.addCultureInterest(member.getEmail(), culture.getCultureId());
+
+        //then
+        log.info("관심수: {}", interestCount);
+
+        Assertions.assertEquals(member.getCultureInterests().size(), 2);
+        Assertions.assertEquals(culture.getCultureInterests().size(), 2);
+        Assertions.assertEquals(culture.getInterestCount(), interestCount);
+
+
+    }
+}


### PR DESCRIPTION
관심 문화가 토글(이미 있을 시 -> 삭제, 없을 시 -> 추가)되는 기능을 추가했습니다.
원래는 추가/삭제 API 따로 있었는데 와이어프레임 보니까 관심 버튼 하나로 추가 삭제가 모두 이루어져 하나의 API로 변경했습니다.
